### PR TITLE
fix: change .temp folder to temp

### DIFF
--- a/packages/utils-scripts/lib/config/base.js
+++ b/packages/utils-scripts/lib/config/base.js
@@ -11,7 +11,7 @@ module.exports = {
     src: path.join(distCwd, 'src'),
     config: path.join(__dirname, '../config'),
     template: path.join(__dirname, '../../docs-template'),
-    esTemp: path.join(distCwd, '.temp'),
+    esTemp: path.join(distCwd, 'temp'),
     dist: path.join(distCwd, 'dist'),
     publishCache: path.join(distCwd, '.publish'),
     docCache: path.join(distCwd, '.docs'),

--- a/packages/utils-scripts/lib/config/esdoc.js
+++ b/packages/utils-scripts/lib/config/esdoc.js
@@ -15,7 +15,7 @@ module.exports = {
         {
             name: 'esdoc-importpath-plugin',
             option: {
-                replaces: [{ from: '.temp/', to: '' }],
+                replaces: [{ from: 'temp/', to: '' }],
             },
         },
         {

--- a/packages/utils-scripts/src/config/base.js
+++ b/packages/utils-scripts/src/config/base.js
@@ -12,7 +12,7 @@ module.exports = {
   src: path.join(distCwd, 'src'),
   config: path.join(__dirname, '../config'),
   template: path.join(__dirname, '../../docs-template'),
-  esTemp: path.join(distCwd, '.temp'),
+  esTemp: path.join(distCwd, 'temp'),
   dist: path.join(distCwd, 'dist'),
   publishCache: path.join(distCwd, '.publish'),
   docCache: path.join(distCwd, '.docs'),

--- a/packages/utils-scripts/src/config/esdoc.js
+++ b/packages/utils-scripts/src/config/esdoc.js
@@ -15,7 +15,7 @@ module.exports = {
     {
       name: 'esdoc-importpath-plugin',
       option: {
-        replaces: [{ from: '.temp/', to: '' }],
+        replaces: [{ from: 'temp/', to: '' }],
       },
     },
     {


### PR DESCRIPTION
koa-static middleware doesn't support hidden folders with default settings, althougn we can add {hidden: true} options to make it works. But since we have a lot of jobs which depend on this folder now, it should not be hidden anymore.